### PR TITLE
Ignore sass cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
+.sass-cache
 _site


### PR DESCRIPTION
Ignore the sass cache when running bundle serve.
